### PR TITLE
adds jinja example and packages

### DIFF
--- a/analysis/generate_coffee_shop_sources.sql
+++ b/analysis/generate_coffee_shop_sources.sql
@@ -1,0 +1,24 @@
+{{ codegen.generate_base_model(
+    source_name='coffee_shop',
+    table_name='customers'
+) }}
+
+{{ codegen.generate_base_model(
+    source_name='coffee_shop',
+    table_name='orders'
+) }}
+
+{{ codegen.generate_base_model(
+    source_name='coffee_shop',
+    table_name='order_items'
+) }}
+
+{{ codegen.generate_base_model(
+    source_name='coffee_shop',
+    table_name='products'
+) }}
+
+{{ codegen.generate_base_model(
+    source_name='coffee_shop',
+    table_name='product_prices'
+) }}

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -36,3 +36,11 @@ models:
       # Applies to all files under models/example/
       example:
           materialized: view
+
+# Point github package at right schema
+
+vars:
+  github_source:
+    github_database: analytics-engineers-club
+    github_schema: github
+  github__using_repo_team: false 

--- a/macros/test_greater_than_zero.sql
+++ b/macros/test_greater_than_zero.sql
@@ -1,0 +1,7 @@
+{% test greater_than_zero(model, column_name) %}
+    select
+        {{ column_name }}
+
+    from {{ model }}
+		where {{ column_name }} <= 0
+{% endtest %}

--- a/models/marts/core/calendar_dates.sql
+++ b/models/marts/core/calendar_dates.sql
@@ -1,0 +1,6 @@
+{{ dbt_utils.date_spine(
+    datepart="day",
+    start_date="cast('2021-01-01' as date)",
+    end_date="cast('2021-12-01' as date)"
+   )
+}}

--- a/models/marts/core/core.yml
+++ b/models/marts/core/core.yml
@@ -41,3 +41,6 @@ models:
         tests:
           - unique
           - not_null
+      - name: price
+        tests:
+          - greater_than_zero

--- a/models/marts/core/monthly_revenue_by_category.sql
+++ b/models/marts/core/monthly_revenue_by_category.sql
@@ -1,0 +1,45 @@
+{{ config(materialized="table")}}
+
+{% set product_categories = ["merch","coffee beans","brewing supplies"] %}
+
+with order_items as ( 
+    
+    select * from {{ ref('order_items')}}
+
+),   orders as (
+
+    select * from {{ ref('orders')}}
+
+),   products as ( 
+
+    select * from {{ ref('products')}}
+
+),   product_prices as (
+
+    select * from {{ ref('product_prices')}}
+
+)
+
+select
+    date_trunc(orders.created_at, month) as order_month,
+
+    {% for product_category in product_categories %}
+    round(sum(case when products.category = '{{product_category}}' then product_prices.price end) / 100,2) as {{product_category|replace(" ","_")}}_amount,
+    {% endfor %}
+        
+    round(sum(product_prices.price / 100),2) as total_sales,
+
+from order_items
+
+left join orders
+    on order_items.order_id = orders.order_id
+
+left join products
+    on order_items.product_id = products.product_id
+
+left join product_prices
+  on order_items.product_id = product_prices.product_id
+  and orders.created_at between product_prices.created_at and product_prices.ended_at
+
+group by 1
+order by 1

--- a/models/staging/coffee_shop/src_coffee_shop.yml
+++ b/models/staging/coffee_shop/src_coffee_shop.yml
@@ -27,11 +27,19 @@ sources:
               - not_null
 
       - name: product_prices
+        tests: 
+          - dbt_utils.mutually_exclusive_ranges:
+              lower_bound_column: created_at
+              upper_bound_column: ended_at
+              partition_by: product_id
+              gaps: not_allowed
+              
         columns:
           - name: id
             tests: 
               - unique
               - not_null
+        
 
       - name: order_items
         columns: 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,9 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.7.3
+    version: 0.7.4
+
+  - package: dbt-labs/codegen
+    version: 0.4.0
+
+  - package: fivetran/github
+    version: 0.3.0


### PR DESCRIPTION
This adds work related to the exercises:

- adding a model that uses Jinja: `monthly_revenue_by_category.sql`
- adds `dbt_utils`,`codgen`, and `github` packages
- utilizes macros from  `dbt_utils` and `codgen`